### PR TITLE
Differential update for single files

### DIFF
--- a/__tests__/__fixtures__/fixtures.ts
+++ b/__tests__/__fixtures__/fixtures.ts
@@ -8,6 +8,8 @@ import * as emberTemplateLintWithErrors from './ember-template-lint-with-errors.
 import * as emberTemplateLintWithWarnings from './ember-template-lint-with-warnings.json';
 import * as emberTemplateLintNoResults from './ember-template-lint-no-results.json';
 import * as pending from './pending.json';
+import * as singleFilePending from './single-file-pending.json';
+import * as singleFilePendingUpdated from './single-file-pending-updated.json';
 
 export default {
   eslintWithErrors: <ESLint.LintResult[]>(
@@ -29,4 +31,6 @@ export default {
     (<TemplateLintReport>(emberTemplateLintNoResults as unknown)).results
   ),
   pending: <PendingLintMessage[]>pending,
+  singleFilePending: <PendingLintMessage[]>singleFilePending,
+  singleFilePendingUpdated: <PendingLintMessage[]>singleFilePendingUpdated,
 };

--- a/__tests__/__fixtures__/single-file-pending-updated.json
+++ b/__tests__/__fixtures__/single-file-pending-updated.json
@@ -1,0 +1,26 @@
+[
+  {
+    "engine": "eslint",
+    "filePath": "/Users/fake/app/controllers/settings.js",
+    "ruleId": "no-prototype-builtins",
+    "line": 25,
+    "column": 21,
+    "createdDate": 1601332963373
+  },
+  {
+    "engine": "eslint",
+    "filePath": "/Users/fake/app/controllers/settings.js",
+    "ruleId": "no-prototype-builtins",
+    "line": 26,
+    "column": 19,
+    "createdDate": 1601332963373
+  },
+  {
+    "engine": "eslint",
+    "filePath": "/Users/fake/app/controllers/settings.js",
+    "ruleId": "no-prototype-builtins",
+    "line": 50,
+    "column": 101,
+    "createdDate": 1601332963373
+  }
+]

--- a/__tests__/__fixtures__/single-file-pending.json
+++ b/__tests__/__fixtures__/single-file-pending.json
@@ -1,0 +1,26 @@
+[
+  {
+    "engine": "eslint",
+    "filePath": "/Users/fake/app/controllers/settings.js",
+    "ruleId": "no-prototype-builtins",
+    "line": 25,
+    "column": 21,
+    "createdDate": 1601332963373
+  },
+  {
+    "engine": "eslint",
+    "filePath": "/Users/fake/app/controllers/settings.js",
+    "ruleId": "no-prototype-builtins",
+    "line": 26,
+    "column": 19,
+    "createdDate": 1601332963373
+  },
+  {
+    "engine": "eslint",
+    "filePath": "/Users/fake/app/controllers/settings.js",
+    "ruleId": "no-prototype-builtins",
+    "line": 32,
+    "column": 34,
+    "createdDate": 1601332963373
+  }
+]

--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -188,5 +188,21 @@ describe('io', () => {
         ]
       `);
     });
+
+    it('deletes pending files for a specific filePath', async () => {
+      const lintPendingDir = await generatePendingFiles(tmp, fixtures.singleFilePending);
+
+      expect(await readdir(lintPendingDir)).toMatchInlineSnapshot(`
+        Array [
+          "1fa0a511346d560f2e57fc9d025c54950347ae2b.json",
+          "a51d0173759432bd1e160c56f4642427e83544d9.json",
+          "a72d388d48e71caa653cff498b756bc479216a00.json",
+        ]
+      `);
+
+      await updatePendingForFile(tmp, '/Users/fake/app/controllers/settings.js', []);
+
+      expect(await readdir(lintPendingDir)).toMatchInlineSnapshot(`Array []`);
+    });
   });
 });

--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -147,7 +147,23 @@ describe('io', () => {
       expect(readdirSync(lintPendingDir)).toHaveLength(0);
     });
 
-    it('updates specific pending files for a specific filePath', async () => {
+    it('generates pending files for a specific filePath', async () => {
+      const lintPendingDir = await updatePendingForFile(
+        tmp,
+        '/Users/fake/app/controllers/settings.js',
+        fixtures.singleFilePending
+      );
+
+      expect(await readdir(lintPendingDir)).toMatchInlineSnapshot(`
+        Array [
+          "1fa0a511346d560f2e57fc9d025c54950347ae2b.json",
+          "a51d0173759432bd1e160c56f4642427e83544d9.json",
+          "a72d388d48e71caa653cff498b756bc479216a00.json",
+        ]
+      `);
+    });
+
+    it('updates pending files for a specific filePath', async () => {
       const lintPendingDir = await generatePendingFiles(tmp, fixtures.singleFilePending);
 
       expect(await readdir(lintPendingDir)).toMatchInlineSnapshot(`

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "ember-template-lint": "^2.12.1",
     "eslint": "^7.9.0",
+    "extra-set": "^2.2.4",
     "fs-extra": "^9.0.1"
   },
   "devDependencies": {

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -1,5 +1,9 @@
 import { LintMessage, LintResult, PendingLintMessage } from './types';
 
+/**
+ * @param lintResult The lint result object, either an {ESLint.LintResult} or an {TemplateLintResult}.
+ * @param lintMessage A lint message object representing a specific violation for a file.
+ */
 export function buildPendingLintMessage(
   lintResult: LintResult,
   lintMessage: LintMessage
@@ -14,10 +18,13 @@ export function buildPendingLintMessage(
   };
 }
 
-export function buildPendingLintMessages(results: LintResult[]): PendingLintMessage[] {
-  const lintResults = results.filter((result) => result.messages.length > 0);
+/**
+ * @param lintResults A list of {LintResult} objects to convert to {PendingLintMessage} objects.
+ */
+export function buildPendingLintMessages(lintResults: LintResult[]): PendingLintMessage[] {
+  const results = lintResults.filter((result) => result.messages.length > 0);
 
-  const pendingLintMessages = lintResults.reduce((converted, lintResult) => {
+  const pendingLintMessages = results.reduce((converted, lintResult) => {
     lintResult.messages.forEach((message: LintMessage) => {
       if (message.severity === 2) {
         converted.push(buildPendingLintMessage(lintResult, message));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2360,6 +2360,11 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+extra-set@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/extra-set/-/extra-set-2.2.4.tgz#6f3f7192beefa9315340ccbe6fcfb0c16798caf7"
+  integrity sha512-/Ofjup5WBTyxowhBoCzGDzktXb+Jo1qjSEjMgQUDlbDZP68uzpEkbJBB0+I0OxctENFN2CXlJsuHU+RDx3F7sg==
+
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"


### PR DESCRIPTION
Allows for updating pending items for single files, avoiding the need to regenerate the entire pending list unnecessarily.