### PR TITLE
Make pending lint messages map building public

### DIFF
--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -1,6 +1,11 @@
 import { existsSync, statSync, readdirSync, readdir } from 'fs-extra';
 import { join } from 'path';
-import { generateFileName, generatePendingFiles, getPendingBatches, _getPendingMap } from '../src';
+import {
+  generateFileName,
+  generatePendingFiles,
+  getPendingBatches,
+  buildPendingLintMessagesMap,
+} from '../src';
 import { PendingLintMessage } from '../src/types';
 import { createTmpDir } from './__utils__/tmp-dir';
 import fixtures from './__fixtures__/fixtures';
@@ -277,7 +282,10 @@ describe('io', () => {
     ];
 
     it('creates items to add', async () => {
-      const [add] = await getPendingBatches(_getPendingMap(fromLintResults), new Map());
+      const [add] = await getPendingBatches(
+        buildPendingLintMessagesMap(fromLintResults),
+        new Map()
+      );
 
       expect([...add.keys()]).toMatchInlineSnapshot(`
         Array [
@@ -290,7 +298,10 @@ describe('io', () => {
     });
 
     it('creates items to delete', async () => {
-      const [, remove] = await getPendingBatches(new Map(), _getPendingMap(fromLintResults));
+      const [, remove] = await getPendingBatches(
+        new Map(),
+        buildPendingLintMessagesMap(fromLintResults)
+      );
 
       expect([...remove.keys()]).toMatchInlineSnapshot(`
         Array [
@@ -304,8 +315,8 @@ describe('io', () => {
 
     it('creates all batches', async () => {
       const [add, remove, stable] = await getPendingBatches(
-        _getPendingMap(fromLintResults),
-        _getPendingMap(existing)
+        buildPendingLintMessagesMap(fromLintResults),
+        buildPendingLintMessagesMap(existing)
       );
 
       expect([...add.keys()]).toMatchInlineSnapshot(`

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -1,3 +1,4 @@
+import { generateFileName } from './io';
 import { LintMessage, LintResult, PendingLintMessage } from './types';
 
 /**
@@ -39,6 +40,23 @@ export function buildPendingLintMessages(lintResults: LintResult[]): PendingLint
   }, [] as PendingLintMessage[]);
 
   return pendingLintMessages;
+}
+
+/**
+ * Builds a map of fileHash, pendingLintMessage.
+ *
+ * @param pendingLintMessages The linting data for all violations.
+ */
+export function buildPendingLintMessagesMap(
+  pendingLintMessages: PendingLintMessage[]
+): Map<string, PendingLintMessage> {
+  return new Map(
+    pendingLintMessages.map((currentLintMessage: PendingLintMessage) => {
+      const fileName = generateFileName(currentLintMessage);
+
+      return [fileName, currentLintMessage];
+    })
+  );
 }
 
 function getEngine(result: LintResult) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
-export { buildPendingLintMessage, buildPendingLintMessages } from './builders';
+export {
+  buildPendingLintMessage,
+  buildPendingLintMessages,
+  buildPendingLintMessagesMap,
+} from './builders';
 export {
   ensurePendingDir,
   getPendingDirPath,
@@ -6,5 +10,4 @@ export {
   generatePendingFiles,
   readPendingFiles,
   getPendingBatches,
-  _getPendingMap,
 } from './io';

--- a/src/io.ts
+++ b/src/io.ts
@@ -2,6 +2,7 @@ import { createHash } from 'crypto';
 import { join, parse } from 'path';
 import { ensureDir, readdir, readJSON, unlink, writeFile } from 'fs-extra';
 import { PendingLintMessage } from './types';
+import { buildPendingLintMessagesMap } from './builders';
 
 /**
  * Creates, or ensures the creation of, the .lint-pending directory.
@@ -51,7 +52,10 @@ export async function generatePendingFiles(
 
   const existing: Map<string, PendingLintMessage> = await readPendingFiles(pendingDir, filePath);
 
-  const [add, remove] = await getPendingBatches(_getPendingMap(pendingLintMessages), existing);
+  const [add, remove] = await getPendingBatches(
+    buildPendingLintMessagesMap(pendingLintMessages),
+    existing
+  );
 
   await _generateFiles(baseDir, add, remove);
 
@@ -131,16 +135,4 @@ async function _generateFiles(
   for (const [fileHash] of remove) {
     await unlink(join(path, `${fileHash}.json`));
   }
-}
-
-export function _getPendingMap(
-  pendingLintMessages: PendingLintMessage[]
-): Map<string, PendingLintMessage> {
-  return new Map(
-    pendingLintMessages.map((currentLintMessage: PendingLintMessage) => {
-      const fileName = generateFileName(currentLintMessage);
-
-      return [fileName, currentLintMessage];
-    })
-  );
 }


### PR DESCRIPTION
Exposing the `buildPendingLintMessagesMap` function to provide public access to this functionality.